### PR TITLE
Fix: Redirects with baseurl

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,4 @@
+RewriteEngine on
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteRule ^(.*)$ index.php/$1 [QSA,L]


### PR DESCRIPTION
omit the necessary of index.php in baseurl and the wrong creation of static content links

Without .htaccess includes look like this:
<link rel="stylesheet" href="//mongo-admin.XXXXXX.XX/index.php/static/css/font-awesome.min.css">

With .htaccess:
Now you can request https://mongo-admin.XXXXXX.XX/login and the includes look like this:
<link rel="stylesheet" href="//mongo-admin.XXXXXX.XX/static/css/font-awesome.min.css">
